### PR TITLE
docs(table): add docs for @ctablex/table

### DIFF
--- a/packages/ctablex-table/docs/COMPONENTS.md
+++ b/packages/ctablex-table/docs/COMPONENTS.md
@@ -1,0 +1,1370 @@
+# Components API Reference
+
+Complete reference for all components in **@ctablex/table**.
+
+## Table of Contents
+
+- [DataTable](#datatable)
+- [Columns](#columns)
+- [Column](#column)
+- [Table](#table)
+- [TableHeader](#tableheader)
+- [HeaderRow](#headerrow)
+- [HeaderCell](#headercell)
+- [TableBody](#tablebody)
+- [Rows](#rows)
+- [Row](#row)
+- [Cell](#cell)
+- [TableFooter](#tablefooter)
+- [Table Elements Context](#table-elements-context)
+- [Re-exported Components](#re-exported-components)
+
+---
+
+## DataTable
+
+The root component that extracts and provides column definitions and data to the table.
+It serves two main purposes:
+
+- Extract column definitions from `<Columns>` components and provide them via columns context
+- Provide data to the table via content context
+
+### Behavior
+
+This component does not render any DOM elements itself.
+
+First, it extracts column definitions from its immediate children, typically `<Columns>` components. Any component can be marked as a definition by setting the `__COLUMNS__` static property to `true` on its type.
+
+Next, it optionally accepts a `data` prop and provides it via content context. If the `data` prop is not provided but content context already contains data, it uses the existing data. If neither is available, it throws an error.
+
+Finally, it renders its children with definition components removed from the tree.
+
+### Examples
+
+**Extracting column definitions:**
+
+```tsx
+<DataTable data={data}>
+  <Columns>Columns definition...</Columns>
+  <div>Other children...</div>
+</DataTable>
+```
+
+The `<Columns>` component is extracted and removed from the render tree. Only `<div>Other children...</div>` is rendered.
+
+**Error case - no data available:**
+
+```tsx
+<DataTable>{/* Children */}</DataTable>
+```
+
+Throws an error because neither `data` prop nor content context provides data.
+
+**Basic usage with data prop:**
+
+```tsx
+<DataTable data={data}>{/* Children */}</DataTable>
+```
+
+Provides `data` to children via content context.
+
+**Using existing content context:**
+
+```tsx
+<ContentProvider value={data}>
+  <DataTable>{/* Children */}</DataTable>
+</ContentProvider>
+```
+
+No `data` prop needed—uses the existing data from content context.
+
+**Data prop overrides context:**
+
+```tsx
+<ContentProvider value={outer}>
+  <DataTable data={inner}>{/* Children */}</DataTable>
+</ContentProvider>
+```
+
+The `data` prop takes precedence. Children receive `inner` instead of `outer`.
+
+**Using with data fetching components:**
+
+```tsx
+<UserDataProvider>
+  <DataTable>{/* Children */}</DataTable>
+</UserDataProvider>
+```
+
+`<UserDataProvider>` fetches and provides user data via content context. `<DataTable>` uses that data without needing a `data` prop.
+
+**Custom column container components:**
+
+```tsx
+function MyColumns() {
+  return (
+    <>
+      <Column accessor="name" header="Name" />
+      <Column accessor="age" header="Age" />
+    </>
+  );
+}
+MyColumns.__COLUMNS__ = true; // Mark as column container
+```
+
+You can create reusable column definition components by marking them with `__COLUMNS__ = true`.
+
+```tsx
+<DataTable data={items}>
+  <MyColumns />
+</DataTable>
+```
+
+`<MyColumns />` is extracted and removed from the render tree because it's marked as a column container.
+
+**Non-immediate children are not extracted:**
+
+```tsx
+<DataTable data={items}>
+  <>
+    <Columns>{/* ... */}</Columns>
+  </>
+</DataTable>
+```
+
+The `<Columns>` component is wrapped in a fragment, so it's not an immediate child. It will be rendered instead of being extracted. Read more about this behavior in the [Columns](./COMPONENTS.md#columns) documentation.
+
+## Columns
+
+Container for column definitions. It is marked as a column definition by setting the `__COLUMNS__` static property to `true` on its type and is extracted by `<DataTable>` when it is an immediate child.
+
+When it is not an immediate child of `<DataTable>`, it will be rendered. It does not render any DOM elements itself and does not render its own children. Instead, it renders children provided by `<DataTable>` via columns context.
+
+It also accepts a `part` prop to identify different column groups. When a `part` prop is provided, it renders only the children of the matching part from columns context. If more than one `<Columns>` with the same `part` exists, all definitions are rendered.
+
+### Examples
+
+**Common usage scenario:**
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column accessor="id" header="ID" />
+    <Column accessor="name" header="Name" />
+  </Columns>
+  <Table />
+</DataTable>
+```
+
+The `<Columns>` component is extracted by `<DataTable>`, and the column definitions are provided to `<Table>` via columns context. `<Table />` expands to its default children:
+
+```tsx
+<Table>
+  <TableHeader>
+    <HeaderRow>
+      <Columns />
+    </HeaderRow>
+  </TableHeader>
+  <TableBody>
+    <Rows>
+      <Row>
+        <Columns />
+      </Row>
+    </Rows>
+  </TableBody>
+</Table>
+```
+
+When `<Columns />` is rendered in different contexts (header vs body), it outputs the same column definitions. This allows you to define columns once and use them in multiple places.
+
+**Basic usage:**
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <span>in Columns</span>
+  </Columns>
+  <div>
+    <span>outside Columns</span>
+    <Columns />
+  </div>
+</DataTable>
+```
+
+The `<Columns>` definition is extracted by `<DataTable>`. When rendered inside the `<div>`, it outputs its defined children:
+
+```html
+<div>
+  <span>outside Columns</span>
+  <span>in Columns</span>
+</div>
+```
+
+**Using the `part` prop:**
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <span>no part</span>
+  </Columns>
+  <Columns part="detail">
+    <span>in Detail</span>
+  </Columns>
+  <div>
+    <span>outside Columns</span>
+    <Columns />
+    <div class="detail">
+      <Columns part="detail" />
+    </div>
+  </div>
+</DataTable>
+```
+
+The first `<Columns />` renders the default definition, while `<Columns part="detail" />` renders the matching part:
+
+```html
+<div>
+  <span>outside Columns</span>
+  <span>no part</span>
+  <div class="detail">
+    <span>in Detail</span>
+  </div>
+</div>
+```
+
+## Column
+
+The Column component behaves differently depending on its rendering context. This dual behavior helps keep header and data cell definitions together in one place.
+
+**Inside a header context** (e.g., within `<TableHeader>`):
+
+The Column renders a `<HeaderCell>` component (`<th>` element) and passes the `header` prop as its children. It also passes the `thEl` prop to the `HeaderCell` as the `el` prop.
+
+```tsx
+<HeaderCell el={props.thEl}>{props.header}</HeaderCell>
+```
+
+**Outside a header context** (e.g., within `<TableBody>`):
+
+The Column renders a `<Cell>` component (`<td>` element) and passes the `accessor` prop to `Cell` as the data accessor. It also passes the `el` prop to `Cell` as the `el` prop. It also passes its children to Cell. Default children of `Column` is `<DefaultContent />`.
+
+```tsx
+<Cell accessor={props.accessor} el={props.el}>
+  {children}
+</Cell>
+```
+
+<!-- default children of Column is <DefaultContent /> -->
+
+## Table
+
+Renders the `<table>` element and its structure. It has default children `<TableHeader>` and `<TableBody>`, but you can customize the structure by providing your own children.
+
+The element that `<Table>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<table>` element is rendered.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<Table />
+```
+
+This is the same as:
+
+```tsx
+<Table>
+  <TableHeader />
+  <TableBody />
+</Table>
+```
+
+**Customizing table structure:**
+
+```tsx
+<Table>
+  <TableHeader />
+  <TableBody />
+  <TableFooter />
+</Table>
+```
+
+You can override the default children to add additional sections like a footer.
+
+**Customizing table element:**
+
+```tsx
+<Table el={<table className="my-table" />} />
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  table: <table className="app-table" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <Table />
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ table: <table className="app-table" /> }}>
+  <Table el={<table className="my-table" />} />
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered table will have the class `my-table`.
+
+**Replacing table with a different element:**
+
+```tsx
+<Table el={<div className="grid" />} />
+```
+
+Renders a `<div>` with class `grid` instead of a `<table>`.
+
+**Warning about `el` children:**
+
+```tsx
+<Table el={<div>el child</div>}>children</Table>
+```
+
+Renders `<div>el child</div>` and ignores `children`. The `el` prop's children take precedence over `<Table>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<Table>`'s children instead to maintain clarity and expected behavior.
+
+## TableHeader
+
+Renders the `<thead>` element. It has default children `<HeaderRow />`, but you can customize by providing your own children.
+
+The element that `<TableHeader>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<thead>` element is rendered.
+
+The component also provides header context (`IsHeaderContext` set to `true`) which is used by `<Column>` components to determine whether they should render as header cells (`<th>`) or data cells (`<td>`).
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<TableHeader />
+```
+
+This is the same as:
+
+```tsx
+<TableHeader>
+  <HeaderRow />
+</TableHeader>
+```
+
+**Customizing header structure:**
+
+```tsx
+<TableHeader>
+  <HeaderRow />
+  <HeaderRow />
+</TableHeader>
+```
+
+You can provide multiple header rows or other custom structure.
+
+**Customizing thead element:**
+
+```tsx
+<TableHeader el={<thead className="my-header" />} />
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  thead: <thead className="app-header" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <TableHeader />
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ thead: <thead className="app-header" /> }}>
+  <TableHeader el={<thead className="my-header" />} />
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered thead will have the class `my-header`.
+
+**Replacing thead with a different element:**
+
+```tsx
+<TableHeader el={<div className="header-section" />} />
+```
+
+Renders a `<div>` with class `header-section` instead of a `<thead>`.
+
+**Warning about `el` children:**
+
+```tsx
+<TableHeader el={<thead>el child</thead>}>children</TableHeader>
+```
+
+Renders `<thead>el child</thead>` and ignores `children`. The `el` prop's children take precedence over `<TableHeader>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<TableHeader>`'s children instead to maintain clarity and expected behavior.
+
+## HeaderRow
+
+Renders the `<tr>` element for the header row. It has default children `<Columns />`, but you can customize by providing your own children.
+
+The element that `<HeaderRow>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<tr>` element is rendered.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<HeaderRow />
+```
+
+This is the same as:
+
+```tsx
+<HeaderRow>
+  <Columns />
+</HeaderRow>
+```
+
+**Customizing header row content:**
+
+```tsx
+<HeaderRow>
+  <th>ID</th>
+  <th>Name</th>
+</HeaderRow>
+```
+
+You can provide custom content or use specific column parts.
+
+**Customizing tr element:**
+
+```tsx
+<HeaderRow el={<tr className="my-header-row" />} />
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  tr: <tr className="app-row" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <HeaderRow />
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ tr: <tr className="app-row" /> }}>
+  <HeaderRow el={<tr className="my-header-row" />} />
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered tr will have the class `my-header-row`.
+
+**Replacing tr with a different element:**
+
+```tsx
+<HeaderRow el={<div className="header-row" />} />
+```
+
+Renders a `<div>` with class `header-row` instead of a `<tr>`.
+
+**Warning about `el` children:**
+
+```tsx
+<HeaderRow el={<tr>el child</tr>}>children</HeaderRow>
+```
+
+Renders `<tr>el child</tr>` and ignores `children`. The `el` prop's children take precedence over `<HeaderRow>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<HeaderRow>`'s children instead to maintain clarity and expected behavior.
+
+## HeaderCell
+
+Renders the `<th>` element for table headers. This component does not have default children.
+
+The element that `<HeaderCell>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<th>` element is rendered.
+
+**Note:** Most of the time, this component is not used directly. Instead, it is rendered by the `<Column>` component when inside a header context (e.g., within `<TableHeader>`). `header` and `thEl` props of `<Column>` are passed to `<HeaderCell>` as children and `el` respectively.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<HeaderCell>Name</HeaderCell>
+```
+
+Renders a simple header cell with text content.
+
+**Typical usage via Column:**
+
+```tsx
+<TableHeader>
+  <HeaderRow>
+    <Column header="Name" accessor="name" />
+  </HeaderRow>
+</TableHeader>
+```
+
+The `<Column>` component internally renders `<HeaderCell>` when in header context. This is the recommended approach.
+
+**Customizing th element:**
+
+```tsx
+<HeaderCell el={<th className="my-header-cell" />}>Name</HeaderCell>
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  th: <th className="app-header-cell" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <HeaderCell>Name</HeaderCell>
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ th: <th className="app-header-cell" /> }}>
+  <HeaderCell el={<th className="my-header-cell" />}>Name</HeaderCell>
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered th will have the class `my-header-cell`.
+
+**Replacing th with a different element:**
+
+```tsx
+<HeaderCell el={<div className="header-cell" />}>Name</HeaderCell>
+```
+
+Renders a `<div>` with class `header-cell` instead of a `<th>`.
+
+**Warning about `el` children:**
+
+```tsx
+<HeaderCell el={<th>el child</th>}>children</HeaderCell>
+```
+
+Renders `<th>el child</th>` and ignores `children`. The `el` prop's children take precedence over `<HeaderCell>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<HeaderCell>`'s children instead to maintain clarity and expected behavior.
+
+## TableBody
+
+Renders the `<tbody>` element for the table body. It has default children `<Rows />`, but you can customize by providing your own children.
+
+The element that `<TableBody>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<tbody>` element is rendered.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<TableBody />
+```
+
+This is the same as:
+
+```tsx
+<TableBody>
+  <Rows />
+</TableBody>
+```
+
+**Customizing tbody element:**
+
+```tsx
+<TableBody el={<tbody className="my-body" />} />
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  tbody: <tbody className="app-body" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <TableBody />
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ tbody: <tbody className="app-body" /> }}>
+  <TableBody el={<tbody className="my-body" />} />
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered tbody will have the class `my-body`.
+
+**Replacing tbody with a different element:**
+
+```tsx
+<TableBody el={<div className="body-section" />} />
+```
+
+Renders a `<div>` with class `body-section` instead of a `<tbody>`.
+
+**Custom body structure:**
+
+```tsx
+<TableBody>
+  <Rows />
+  <tr>
+    <td colSpan={3}>Custom summary row</td>
+  </tr>
+</TableBody>
+```
+
+You can provide custom content in addition to or instead of `<Rows />`.
+
+**Warning about `el` children:**
+
+```tsx
+<TableBody el={<tbody>el child</tbody>}>children</TableBody>
+```
+
+Renders `<tbody>el child</tbody>` and ignores `children`. The `el` prop's children take precedence over `<TableBody>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<TableBody>`'s children instead to maintain clarity and expected behavior.
+
+## Rows
+
+Iterates over data items and renders a row for each item. This component does not render any DOM elements itself.
+
+It has default children `<Row />` which is rendered for each item in the data array. You can customize by providing your own children.
+
+The component uses `<ArrayContent>` from `@ctablex/core` to iterate over items from content context. It also accepts a `keyAccessor` prop to extract React keys from each item. If not provided, the array index is used as the key.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<Rows />
+```
+
+This is the same as:
+
+```tsx
+<Rows>
+  <Row />
+</Rows>
+```
+
+Renders a `<Row />` for each item in the data array from content context.
+
+**Using keyAccessor:**
+
+```tsx
+<Rows keyAccessor="id" />
+```
+
+Extracts the `id` property from each data item to use as the React key. This is recommended for avoiding reconciliation issues, specially when stateful components are used inside rows.
+
+**Custom row components:**
+
+```tsx
+<Rows>
+  <Row el={<tr className="data-row" />} />
+</Rows>
+```
+
+You can customize the row component that gets rendered for each item.
+
+**Multiple row types:**
+
+```tsx
+<Rows>
+  <Row />
+  <Row el={<tr className="detail-row" />}>
+    <td colSpan={3}>
+      <Columns part="detail" />
+    </td>
+  </Row>
+</Rows>
+```
+
+Renders multiple rows for each data item. This is useful for master-detail patterns.
+
+## Row
+
+Renders the `<tr>` element for a table row. It has default children `<Columns />`, but you can customize by providing your own children.
+
+The element that `<Row>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<tr>` element is rendered.
+
+By default, the component reads data from content context. This can be overridden by providing a `row` prop. If the `row` prop is provided, that data will be provided as content context for the children instead.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<Row />
+```
+
+This is the same as:
+
+```tsx
+<Row>
+  <Columns />
+</Row>
+```
+
+**Customizing tr element:**
+
+```tsx
+<Row el={<tr className="my-row" />} />
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  tr: <tr className="app-row" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <Row />
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ tr: <tr className="app-row" /> }}>
+  <Row el={<tr className="my-row" />} />
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered tr will have the class `my-row`.
+
+**Overriding row data:**
+
+```tsx
+<Row row={customData}>
+  <Columns />
+</Row>
+```
+
+Provides `customData` to children via content context instead of the data from parent context. This is useful for special rows like summaries.
+
+**Custom row content:**
+
+```tsx
+<Row>
+  <td>Custom</td>
+  <Columns />
+  <td>Actions</td>
+</Row>
+```
+
+You can mix custom cells with column-based cells.
+
+**Replacing tr with a different element:**
+
+```tsx
+<Row el={<div className="row" />} />
+```
+
+Renders a `<div>` with class `row` instead of a `<tr>`.
+
+**Warning about `el` children:**
+
+```tsx
+<Row el={<tr>el child</tr>}>children</Row>
+```
+
+Renders `<tr>el child</tr>` and ignores `children`. The `el` prop's children take precedence over `<Row>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<Row>`'s children instead to maintain clarity and expected behavior.
+
+## Cell
+
+Renders the `<td>` element for table data cells. This component does not have default children.
+
+The element that `<Cell>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<td>` element is rendered.
+
+The component accepts an `accessor` prop to read data from content context. It extracts the value using the accessor and provides it via content context to its children. If the `accessor` is undefined, the content context is passed as is without extraction.
+
+**Note:** Most of the time, this component is not used directly. Instead, it is rendered by the `<Column>` component when outside a header context. The `accessor`, `el`, and `children` props of `<Column>` are passed to `<Cell>`. While `<Cell>` itself has no default children, `<Column>` provides `<DefaultContent />` as default children.
+
+**Note:** The `el` prop renders inside the content extracted by `accessor`. This means custom element components can access the extracted value via `useContent()`. If you need access to the entire item instead of just the extracted value, omit the `accessor` prop and use `<ContentValue />` with its own `accessor` in the children.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<Cell accessor="name">
+  <DefaultContent />
+</Cell>
+```
+
+Reads the `name` property from content context and provides it to children.
+
+**Typical usage via Column:**
+
+```tsx
+<TableBody>
+  <Rows>
+    <Row>
+      <Column accessor="name" header="Name" />
+    </Row>
+  </Rows>
+</TableBody>
+```
+
+The `<Column>` component internally renders `<Cell>` when outside header context.
+
+**Customizing td element:**
+
+```tsx
+<Cell accessor="price" el={<td className="my-cell" />}>
+  <DefaultContent />
+</Cell>
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  td: <td className="app-cell" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <Cell accessor="name">
+    <DefaultContent />
+  </Cell>
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ td: <td className="app-cell" /> }}>
+  <Cell accessor="price" el={<td className="my-cell" />}>
+    <DefaultContent />
+  </Cell>
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered td will have the class `my-cell`.
+
+**No accessor (pass through):**
+
+```tsx
+<Cell>
+  <CustomComponent />
+</Cell>
+```
+
+Without an `accessor`, the entire content context is passed to children unchanged. Useful when you want full control over the cell content.
+
+**Custom cell content:**
+
+```tsx
+<Cell accessor="status">
+  <StatusBadge />
+</Cell>
+```
+
+Provide custom components to render the cell content in a specific way.
+
+**Nested accessors:**
+
+```tsx
+<Cell accessor="user.name">
+  <DefaultContent />
+</Cell>
+```
+
+Access nested properties using dot notation.
+
+**Replacing td with a different element:**
+
+```tsx
+<Cell accessor="name" el={<div className="cell" />}>
+  <DefaultContent />
+</Cell>
+```
+
+Renders a `<div>` with class `cell` instead of a `<td>`.
+
+**el accessing extracted content:**
+
+```tsx
+function ColoredTd() {
+  const content = useContent();
+  const color = content === 'Active' ? 'green' : 'red';
+  return <td style={{ color }}>{content}</td>;
+}
+```
+
+```tsx
+<Cell accessor="status" el={<ColoredTd />}>
+  <DefaultContent />
+</Cell>
+```
+
+The custom `ColoredTd` component receives the extracted `status` value via `useContent()` and applies conditional styling.
+
+**el accessing full item:**
+
+```tsx
+function StatusTd(props: Props) {
+  const item = useContent();
+  const color = item.status === 'Active' ? 'green' : 'red';
+  return <td style={{ color }}>{props.children}</td>;
+}
+```
+
+```tsx
+<Cell el={<StatusTd />}>
+  <ContentValue accessor="name">
+    <DefaultContent />
+  </ContentValue>
+</Cell>
+```
+
+Without an `accessor` on `<Cell>`, the custom element receives the full item and can access multiple properties.
+
+**Warning about `el` children:**
+
+```tsx
+<Cell accessor="name" el={<td>el child</td>}>
+  children
+</Cell>
+```
+
+Renders `<td>el child</td>` and ignores `children`. The `el` prop's children take precedence over `<Cell>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<Cell>`'s children instead to maintain clarity and expected behavior.
+
+## TableFooter
+
+Renders the `<tfoot>` element for the table footer. It does not have default children.
+
+The element that `<TableFooter>` renders can be customized via table element context or the `el` prop:
+
+- If the `el` prop is provided, it is used to render the element.
+- If table element context provides a value, it is used to render the element.
+- Otherwise, a default `<tfoot>` element is rendered.
+
+### Examples
+
+**Basic usage:**
+
+```tsx
+<TableFooter>
+  <tr>
+    <td colSpan={3}>Footer content</td>
+  </tr>
+</TableFooter>
+```
+
+**Customizing tfoot element:**
+
+```tsx
+<TableFooter el={<tfoot className="my-footer" />}>
+  <tr>
+    <td colSpan={3}>Footer content</td>
+  </tr>
+</TableFooter>
+```
+
+Use the `el` prop to customize the rendered element with your own props like className.
+
+**Using table element context:**
+
+```tsx
+const elements = {
+  tfoot: <tfoot className="app-footer" />,
+  // other elements...
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <TableFooter>
+    <tr>
+      <td colSpan={3}>Footer content</td>
+    </tr>
+  </TableFooter>
+</TableElementsProvider>
+```
+
+Provide custom elements via context to apply styling consistently across all table components.
+
+**Combining `el` prop and context:**
+
+```tsx
+<TableElementsProvider value={{ tfoot: <tfoot className="app-footer" /> }}>
+  <TableFooter el={<tfoot className="my-footer" />}>
+    <tr>
+      <td colSpan={3}>Footer content</td>
+    </tr>
+  </TableFooter>
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context. The rendered tfoot will have the class `my-footer`.
+
+**Replacing tfoot with a different element:**
+
+```tsx
+<TableFooter el={<div className="footer-section" />}>
+  <span>Footer content</span>
+</TableFooter>
+```
+
+Renders a `<div>` with class `footer-section` instead of a `<tfoot>`.
+
+**Warning about `el` children:**
+
+```tsx
+<TableFooter el={<tfoot>el child</tfoot>}>children</TableFooter>
+```
+
+Renders `<tfoot>el child</tfoot>` and ignores `children`. The `el` prop's children take precedence over `<TableFooter>`'s children.
+
+**Note:** Avoid passing children to the `el` prop. Use `<TableFooter>`'s children instead to maintain clarity and expected behavior.
+
+## Table Elements Context
+
+The table elements context system allows you to customize the HTML elements used throughout your tables. This is particularly useful when integrating with UI frameworks like Material-UI, Ant Design, or other component libraries where you want to replace standard HTML table elements with custom components.
+
+### API
+
+- **`TableElementsProvider`**: Context provider component that supplies custom table element components to all descendant table components.
+- **`useTableElements()`**: Hook that returns the current table elements from context. Returns `defaultTableElements` if no custom elements are provided.
+- **`defaultTableElements`**: The default set of HTML table elements (`<table>`, `<thead>`, `<tbody>`, `<tfoot>`, `<tr>`, `<th>`, `<td>`). These are used when no custom elements are provided via context.
+- **`TableElements`**: TypeScript type definition for the table elements object structure.
+
+### How It Works
+
+When you provide custom elements via `TableElementsProvider`, all table components (`Table`, `TableHeader`, `TableBody`, `TableFooter`, `HeaderRow`, `Row`, `HeaderCell`, `Cell`) will use your custom elements instead of the default HTML elements. Each component checks for custom elements in this order:
+
+1. The `el` prop on the component (highest priority)
+2. Elements from `TableElementsProvider` context
+3. Default HTML elements (fallback)
+
+This provides flexibility: use context for global styling, and use the `el` prop for component-specific overrides.
+
+### Examples
+
+**Basic usage with custom styling:**
+
+```tsx
+const customElements: TableElements = {
+  table: <table className="custom-table" />,
+  thead: <thead className="custom-thead" />,
+  tbody: <tbody className="custom-tbody" />,
+  tfoot: <tfoot className="custom-tfoot" />,
+  tr: <tr className="custom-tr" />,
+  th: <th className="custom-th" />,
+  td: <td className="custom-td" />,
+};
+```
+
+```tsx
+<TableElementsProvider value={customElements}>
+  <DataTable data={data}>
+    <Columns>
+      <Column accessor="name" header="Name" />
+      <Column accessor="price" header="Price" />
+    </Columns>
+    <Table />
+  </DataTable>
+</TableElementsProvider>
+```
+
+All table elements will now use your custom classes.
+
+**Accessing table elements via hook:**
+
+```tsx
+function MyCustomCell({ children }: { children: ReactNode }) {
+  const elements = useTableElements();
+  return cloneElement(elements.td, { className: 'my-custom-td' }, children);
+}
+```
+
+Use this pattern when you need to access the current table elements to create custom wrapper components.
+
+**Integration with Material-UI:**
+
+```tsx
+import {
+  Table as MuiTable,
+  TableHead as MuiTableHead,
+  TableBody as MuiTableBody,
+  TableFooter as MuiTableFooter,
+  TableRow as MuiTableRow,
+  TableCell as MuiTableCell,
+} from '@mui/material';
+
+const muiElements: TableElements = {
+  table: <MuiTable />,
+  thead: <MuiTableHead />,
+  tbody: <MuiTableBody />,
+  tfoot: <MuiTableFooter />,
+  tr: <MuiTableRow />,
+  th: <MuiTableCell />, // MUI TableCell renders as a <th> in <TableHead /> and <td> in <TableBody /> by default.
+  td: <MuiTableCell />,
+};
+```
+
+```tsx
+<TableElementsProvider value={muiElements}>
+  <DataTable data={products}>
+    <Columns>
+      <Column accessor="name" header="Name" />
+      <Column accessor="price" header="Price" />
+    </Columns>
+    <Table />
+  </DataTable>
+</TableElementsProvider>
+```
+
+This seamlessly integrates ctablex with Material-UI components.
+
+**Partial customization:**
+
+```tsx
+const partialElements: TableElements = {
+  ...defaultTableElements,
+  th: <th className="header-cell" />,
+  td: <td className="data-cell" />,
+};
+```
+
+```tsx
+<TableElementsProvider value={partialElements}>
+  <DataTable data={data}>
+    <Columns>
+      <Column accessor="name" header="Name" />
+    </Columns>
+    <Table />
+  </DataTable>
+</TableElementsProvider>
+```
+
+Customize only specific elements while keeping the defaults for others.
+
+**Context with el prop override:**
+
+```tsx
+const elements: TableElements = {
+  ...defaultTableElements,
+  td: <td className="default-cell" />,
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <DataTable data={data}>
+    <Columns>
+      {/* This cell gets 'default-cell' from context */}
+      <Column accessor="name" header="Name" />
+      {/* This cell gets 'price-cell' from el prop - overrides context */}
+      <Column
+        accessor="price"
+        header="Price"
+        el={<td className="price-cell" />}
+      />
+    </Columns>
+    <Table />
+  </DataTable>
+</TableElementsProvider>
+```
+
+The `el` prop takes precedence over context elements.
+
+**Multiple tables with different styles:**
+
+```tsx
+const blueElements: TableElements = {
+  ...defaultTableElements,
+  table: <table className="blue-table" />,
+};
+
+const greenElements: TableElements = {
+  ...defaultTableElements,
+  table: <table className="green-table" />,
+};
+```
+
+```tsx
+<div>
+  <TableElementsProvider value={blueElements}>
+    <DataTable data={users}>
+      <Columns>
+        <Column accessor="name" header="User" />
+      </Columns>
+      <Table />
+    </DataTable>
+  </TableElementsProvider>
+
+  <TableElementsProvider value={greenElements}>
+    <DataTable data={products}>
+      <Columns>
+        <Column accessor="name" header="Product" />
+      </Columns>
+      <Table />
+    </DataTable>
+  </TableElementsProvider>
+</div>
+```
+
+Use separate providers to style different tables independently.
+
+**Creating a reusable themed table provider:**
+
+```tsx
+function ThemedTableProvider({
+  theme,
+  children,
+}: {
+  theme: 'light' | 'dark';
+  children: ReactNode;
+}) {
+  const elements: TableElements = {
+    table: <table className={`table-${theme}`} />,
+    thead: <thead className={`thead-${theme}`} />,
+    tbody: <tbody className={`tbody-${theme}`} />,
+    tfoot: <tfoot className={`tfoot-${theme}`} />,
+    tr: <tr className={`tr-${theme}`} />,
+    th: <th className={`th-${theme}`} />,
+    td: <td className={`td-${theme}`} />,
+  };
+
+  return (
+    <TableElementsProvider value={elements}>{children}</TableElementsProvider>
+  );
+}
+```
+
+```tsx
+<ThemedTableProvider theme="dark">
+  <DataTable data={data}>
+    <Columns>
+      <Column accessor="name" header="Name" />
+    </Columns>
+    <Table />
+  </DataTable>
+</ThemedTableProvider>
+```
+
+Wrap the table elements context in a custom provider for reusable theming patterns.
+
+## Re-exported Components
+
+Some components are re-exported from `@ctablex/core` for convenience.
+
+- [DefaultContent](../../ctablex-core/docs/Contents.md#defaultcontent)
+- [NullContent](../../ctablex-core/docs/Contents.md#nullcontent)
+- [ContentValue](../../ctablex-core/docs/Contents.md#contentvalue)

--- a/packages/ctablex-table/docs/OVERVIEW.md
+++ b/packages/ctablex-table/docs/OVERVIEW.md
@@ -1,0 +1,744 @@
+# Overview
+
+This document provides an example and shows how it works, then step by step shows how it can be customized.
+
+## Table of Contents
+
+- [TL;DR](#tldr)
+- [Prerequisites](#prerequisites)
+- [Basic Example](#basic-example)
+  - [Step 1: DataTable extracts and removes Columns](#step-1-datatable-extracts-and-removes-columns)
+  - [Step 2: Table expands to default children](#step-2-table-expands-to-default-children)
+  - [Step 3: TableHeader](#step-3-tableheader)
+  - [Step 4: TableBody](#step-4-tablebody)
+- [Data Providing Patterns](#data-providing-patterns)
+  - [Using the `data` prop](#using-the-data-prop)
+  - [Using Content Context](#using-content-context)
+  - [Using Data Provider Components](#using-data-provider-components)
+- [Customization](#customization)
+  - [Custom Cell Content](#custom-cell-content)
+  - [Custom elements](#custom-elements)
+  - [Table Structure](#table-structure)
+- [Type Safety](#type-safety)
+- [Conclusion](#conclusion)
+
+## TL;DR
+
+- **Basic example and component expansion**: See how a simple `<Table />` component automatically expands into `<TableHeader />`, `<TableBody />`, rows, and cells through default children
+- **Data providing patterns**: Learn three ways to provide data to the table—via `data` prop, content context, or data provider components
+- **Customize cell content**: Learn to create custom content components like `NumberContent` that read from context and format data your way
+- **Customize elements**: Discover how to swap default HTML elements using `TableElementsProvider` or the `el` prop to match your design system
+- **Customize structure**: Explore techniques for changing table structure—add footers, remove headers, render multiple rows per item, or replace the table entirely with custom layouts
+
+## Prerequisites
+
+Before diving into this document, you should understand the **micro-context pattern** that powers ctablex. Read **[@ctablex/core MICRO-CONTEXT.md](../../ctablex-core/docs/MICRO-CONTEXT.md)** to learn about:
+
+- How context flows data through component hierarchies
+- The `ContentProvider` and `useContent` pattern
+- Why this approach enables composable, decoupled components
+
+## Basic Example
+
+This basic example shows how to create a simple data table with two columns: "Name" and "Price". The data is provided as an array of objects.
+
+```tsx
+import { DataTable, Columns, Column, Table } from '@ctablex/table';
+
+function BasicExample() {
+  const products = [
+    { name: 'Apple', price: 1.2 },
+    { name: 'Banana', price: 0.5 },
+    { name: 'Cherry', price: 2.0 },
+  ];
+
+  return (
+    <DataTable data={products}>
+      <Columns>
+        <Column accessor="name" header="Name" />
+        <Column accessor="price" header="Price" />
+      </Columns>
+      <Table />
+    </DataTable>
+  );
+}
+```
+
+This code creates a simple data table displaying the names and prices of fruits.
+
+Final rendered table:
+
+```html
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Apple</td>
+      <td>1.2</td>
+    </tr>
+    <tr>
+      <td>Banana</td>
+      <td>0.5</td>
+    </tr>
+    <tr>
+      <td>Cherry</td>
+      <td>2.0</td>
+    </tr>
+  </tbody>
+</table>
+```
+
+Now let's go step by step to see how this transformation happens.
+
+### Step 1: DataTable extracts and removes Columns
+
+DataTable extracts column definitions (`<Columns>...</Columns>`) from its immediate children, provides them via `ColumnsContext`, and removes them from the render tree. After this step, here's what actually renders:
+
+```tsx
+<DataTable data={products}>
+  {/* Columns removed by DataTable and provided via context */}
+  <Table />
+</DataTable>
+```
+
+### Step 2: Table expands to default children
+
+Because the micro-context pattern passes data via context rather than props, child components don't receive changing data props. This allows us to use proper default children.
+
+`<Table />` expands to its default children: `<TableHeader />` and `<TableBody />`. So now we have the following code, which is exactly the same as above:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader />
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+### Step 3: TableHeader
+
+`TableHeader` also has default children. It expands to `HeaderRow`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>
+      <HeaderRow />
+    </TableHeader>
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+`HeaderRow` also has default children. It expands to `Columns`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>
+      <HeaderRow>
+        <Columns />
+      </HeaderRow>
+    </TableHeader>
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+As you remember, `Columns` was extracted by DataTable from immediate children, and provided via context. So here,
+Columns reads columns from context and renders them here:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>
+      <HeaderRow>
+        {/* Children of <Columns> */}
+        <Column accessor="name" header="Name" />
+        <Column accessor="price" header="Price" />
+      </HeaderRow>
+    </TableHeader>
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+`TableHeader` provides `IsHeaderContext` (set to true). `Column` reads `IsHeaderContext` via `useIsHeader()` and detects that it is rendering in the header, so it renders `HeaderCell`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>
+      <HeaderRow>
+        {/* Name and Price are header props of Column */}
+        <HeaderCell>Name</HeaderCell>
+        <HeaderCell>Price</HeaderCell>
+      </HeaderRow>
+    </TableHeader>
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+### Step 4: TableBody
+
+`TableBody` also has default children. It expands to `Rows`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows />
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`Rows` also has default children. It expands to `Row`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row />
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+Rows with the help of `ArrayContent` (a component from `@ctablex/core` that iterates over arrays) iterates over the products array, providing each item via ContentProvider.
+
+You can think of it like this:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <ContentProvider value={products[0]}>
+        <Row />
+      </ContentProvider>
+      <ContentProvider value={products[1]}>
+        <Row />
+      </ContentProvider>
+      {/* ... for each product ... */}
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`Row` also has default children. It expands to `Columns`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          <Columns />
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+As before, Columns reads columns from context and renders them here:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          {/* Children of <Columns> */}
+          <Column accessor="name" header="Name" />
+          <Column accessor="price" header="Price" />
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`Column` also has default children, so if no children are provided, it uses `<DefaultContent />`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          <Columns>
+            <Column header="Name" accessor="name">
+              <DefaultContent />
+            </Column>
+            <Column header="Price" accessor="price">
+              <DefaultContent />
+            </Column>
+          </Columns>
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`IsHeaderContext` is not provided here, so `Column` detects that it is not rendering in the header, so it renders `Cell`:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          <Columns>
+            <Cell accessor="name">
+              <DefaultContent />
+            </Cell>
+            <Cell accessor="price">
+              <DefaultContent />
+            </Cell>
+          </Columns>
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`Cell` extracts the value from content context using accessor and provides it via `ContentProvider` to its children.
+
+You can think of it like this:
+
+```tsx
+<DataTable data={products}>
+  <Table>
+    <TableHeader>{/* ... */}</TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          <Columns>
+            <Cell>
+              <ContentProvider value={products[i]['name']}>
+                <DefaultContent />
+              </ContentProvider>
+            </Cell>
+            <Cell>
+              <ContentProvider value={products[i]['price']}>
+                <DefaultContent />
+              </ContentProvider>
+            </Cell>
+          </Columns>
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+`DefaultContent` reads the value from content context and renders it.
+
+`Table`, `TableHeader`, `TableBody`, `HeaderRow`, `Row`, `HeaderCell`, `Cell` render appropriate HTML elements like `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, `<td>`. So:
+
+```tsx
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Price</th>
+    </tr>
+  </thead>
+  <tbody>
+    {/* <Rows /> does not render DOM itself, it iterates over products */}
+    <tr>
+      <td>{products[0].name}</td>
+      <td>{products[0].price}</td>
+    </tr>
+    <tr>
+      <td>{products[1].name}</td>
+      <td>{products[1].price}</td>
+    </tr>
+    {/* ... for each product ... */}
+  </tbody>
+</table>
+```
+
+This results in the final rendered table as shown in the basic example.
+
+## Data Providing Patterns
+
+There are three ways to provide data to the table, each suited for different scenarios.
+
+### Using the `data` prop
+
+The simplest approach, as shown in the basic example, is to provide data directly via the `data` prop of `<DataTable>`:
+
+```tsx
+<DataTable data={products}>{/* ... */}</DataTable>
+```
+
+This works well for static data or when the data is already available in the component's scope.
+
+### Using Content Context
+
+You can also provide data via content context using `<ContentProvider>` from `@ctablex/core`:
+
+```tsx
+import { ContentProvider } from '@ctablex/core';
+
+<ContentProvider value={products}>
+  <DataTable>{/* Children */}</DataTable>
+</ContentProvider>;
+```
+
+This is useful when you want to share data between multiple components or when data is provided by a parent component.
+
+### Using Data Provider Components
+
+The recommended pattern for production applications is to provide data via content context in a dedicated data provider component. This component can fetch data, manage loading states, or handle reactive updates internally, then provide the data via content context. For example:
+
+```tsx
+<UserDataProvider>
+  <DataTable>{/* Children */}</DataTable>
+</UserDataProvider>
+```
+
+`<UserDataProvider />` fetches user data and provides it via content context. `<DataTable>` consumes this data without needing a `data` prop. This approach keeps the component tree constant, as no data prop is passed down, which can improve performance and simplify component composition. It also promotes separation of concerns—data fetching logic stays in the provider, while presentation logic stays in the table components.
+
+## Customization
+
+### Custom Cell Content
+
+You can customize the content of each cell by providing your own children to the `Column` component. For example, to format the price and add a suffix:
+
+```tsx
+<DataTable data={products}>
+  <Columns>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price">
+      <NumberContent digits={2} /> dollars
+    </Column>
+  </Columns>
+  <Table />
+</DataTable>
+```
+
+```tsx
+import { useContent } from '@ctablex/core';
+
+function NumberContent({ digits }: { digits: number }) {
+  const value = useContent<number>();
+  return <>{value.toFixed(digits)}</>;
+}
+```
+
+You can define reusable content components like `NumberContent` that read the value from content context using `useContent()` and display it in a customized way. In this example, the `Column` will render "1.20 dollars" where `1.20` comes from `NumberContent` and `" dollars"` is rendered as the second child of the `Column`.
+
+If you need to access multiple values from the item, omit the `accessor` prop from `Column` to pass the entire item through. Then use `ContentValue` to select specific properties within the cell:
+
+```tsx
+<DataTable data={products}>
+  <Columns>
+    <Column header="Name">
+      <ContentValue accessor="firstName" /> <ContentValue accessor="lastName" />
+    </Column>
+    <Column accessor="price" header="Price">
+      <NumberContent digits={2} /> dollars
+    </Column>
+  </Columns>
+  <Table />
+</DataTable>
+```
+
+### Custom elements
+
+Two ways to customize elements used in table rendering:
+
+1. Using `TableElementsContext`: You can provide custom elements for all table components by using the `TableElementsProvider` component.
+2. Using `el` prop: You can provide custom elements for specific components using the `el` prop. Child props will be added to the provided element. `Column` also supports `thEl` prop to provide custom header cell element.
+
+```tsx
+const elements = {
+  table: <table className="fancy-table" />,
+  thead: <thead className="fancy-thead" />,
+  tbody: <tbody className="fancy-tbody" />,
+  tr: <tr className="fancy-tr" />,
+  th: <th className="fancy-th" />,
+  td: <td className="fancy-td" />,
+};
+```
+
+```tsx
+<TableElementsProvider value={elements}>
+  <DataTable data={products}>
+    <Columns>
+      <Column header="Name" accessor="name" />
+      <Column
+        header="Price"
+        accessor="price"
+        el={<td className="price-cell" />}
+        thEl={<th className="price-header" />}
+      >
+        <NumberContent digits={2} /> dollars
+      </Column>
+    </Columns>
+    <Table>
+      <TableHeader />
+      <TableBody>
+        <Rows>
+          <Row el={<CustomRow />} />
+        </Rows>
+      </TableBody>
+    </Table>
+  </DataTable>
+</TableElementsProvider>
+```
+
+`<CustomRow />` will be rendered for each row. It can have access to `ContentContext` via `useContent` and render a customized row based on data.
+
+```tsx
+function CustomRow({ children }: { children: ReactNode }) {
+  const item = useContent<{ name: string; price: number }>();
+  return (
+    <tr className={item.price > 10 ? 'expensive' : 'cheap'}>{children}</tr>
+  );
+}
+```
+
+### Table Structure
+
+A more advanced kind of customization is changing table structure, for example adding a footer. Instead of relying on default children, you can provide your own children to `Table`:
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price" />
+  </Columns>
+  <Table>
+    <TableHeader />
+    <TableBody />
+    <TableFooter>{/* custom footer content */}</TableFooter>
+  </Table>
+</DataTable>
+```
+
+Or you can remove the header:
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price" />
+  </Columns>
+  <Table>
+    <TableBody />
+  </Table>
+</DataTable>
+```
+
+Or render a special row:
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price" />
+  </Columns>
+  <Table>
+    <TableHeader />
+    <TableBody>
+      <tr>
+        <td colSpan={2}>Special Row</td>
+      </tr>
+      {/* default rows */}
+      <Rows />
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+You can render more than one row per item. The `part` prop will help you define more than one columns definition:
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price" />
+  </Columns>
+  <Columns part="description">
+    <Column accessor="description" el={<td colSpan={2} />} />
+  </Columns>
+  <Table>
+    <TableHeader />
+    <TableBody>
+      <Rows>
+        {/* default row. uses <Column/> as default children */}
+        <Row />
+        {/* additional row for description */}
+        <Row>
+          {/* find description columns definition by part="description" from columns context */}
+          <Columns part="description" />
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+You can integrate stateful components directly into the table structure to create interactive tables. A common pattern is expandable rows that reveal additional details on demand:
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column>
+      <ExpandButton />
+    </Column>
+    <Column accessor="name" header="Name" />
+    <Column accessor="price" header="Price" />
+  </Columns>
+  <Columns part="detail">
+    <Column accessor="description" el={<td colSpan={3} />} />
+  </Columns>
+  <Table>
+    <TableHeader />
+    <TableBody>
+      <Rows>
+        <OpenControl>
+          <Row />
+          <ExpandableRow>
+            <Columns part="detail" />
+          </ExpandableRow>
+        </OpenControl>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+In this example:
+
+- **`<OpenControl>`** manages the open/closed state for each row and provides it via context
+- **`<ExpandButton>`** reads the state setter from context to toggle visibility
+- **`<ExpandableRow>`** reads the open state from context and conditionally renders the detail row
+- **`part="detail"`** defines a separate column layout for the expanded content
+
+This pattern leverages the micro-context architecture to share state between components without prop drilling, keeping your code clean and composable.
+
+You can even remove `Table` and implement your own table structure using lower-level components like `ArrayContent` and `ContentValue` from `@ctablex/core`:
+
+```tsx
+import { ArrayContent, ContentValue } from '@ctablex/core';
+
+<DataTable data={data}>
+  <Columns>
+    <span>
+      name:{' '}
+      <b>
+        <ContentValue accessor="name" />
+      </b>
+    </span>
+    <br />
+    <span>
+      price: $
+      <b>
+        <ContentValue accessor="price" />
+      </b>
+    </span>
+  </Columns>
+  <div className="list">
+    <ArrayContent>
+      <div className="item">
+        <Columns />
+      </div>
+    </ArrayContent>
+  </div>
+</DataTable>;
+```
+
+You can also remove `Columns` from immediate children of DataTable and define children of Row and HeaderRow directly:
+
+```tsx
+<DataTable data={data}>
+  <Table>
+    <TableHeader>
+      <HeaderRow>
+        <th>Name</th>
+        <th>Price</th>
+      </HeaderRow>
+    </TableHeader>
+    <TableBody>
+      <Rows>
+        <Row>
+          <td>
+            <ContentValue accessor="name" />
+          </td>
+          <td>
+            <ContentValue accessor="price" />
+          </td>
+        </Row>
+      </Rows>
+    </TableBody>
+  </Table>
+</DataTable>
+```
+
+## Type Safety
+
+Micro-context provides weak type safety. Generic types must be manually specified and cannot be validated across context boundaries. See [MICRO-CONTEXT.md - Weak Type Safety](../../ctablex-core/docs/MICRO-CONTEXT.md#weak-type-safety) for details.
+
+However, when you provide a generic type to the `<Column>` element, strong type safety is provided for the accessor prop, including support for nested paths with autocomplete:
+
+```ts
+interface Product {
+  name: string;
+  price: number;
+  info: {
+    weight: number;
+  };
+}
+```
+
+```tsx
+<DataTable data={data}>
+  <Columns>
+    <Column<Product> accessor="name" header="Name" />
+    <Column<Product> accessor="price" header="Price" />
+    {/* Nested paths are fully supported with autocomplete */}
+    <Column<Product> accessor="info.weight" header="Weight" />
+    {/* Error: Type '"invalidProp"' is not assignable to type 'name' | 'price' | 'info' | 'info.weight' */}
+    <Column<Product> accessor="invalidProp" header="Invalid" />
+  </Columns>
+</DataTable>
+```
+
+The accessor prop supports nested object paths (like `"info.weight"`) with full TypeScript autocomplete and type checking.
+
+## Conclusion
+
+That's the tour! You've seen how `@ctablex/table` works from the ground up:
+
+- **Step-by-step transformation**: How `<Table />` expands into headers, rows, and cells through default children
+- **The micro-context magic**: Data and column definitions flow through context, so you're not passing props everywhere
+- **Three data providing patterns**: Via `data` prop, content context, or dedicated data provider components
+- **Customization levels**: From dropping in a custom content component to completely rebuilding the table structure
+- **Type safety**: Generic types on `<Column>` give you autocomplete and type checking for nested paths
+
+The key insight? Because components use context instead of props, they can have proper default children that automatically work with your data. This means minimal code for simple cases, but you can drill down and customize at any level when you need to.
+
+Start simple, customize when needed. That's the ctablex way. Happy coding! 🚀


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive API reference for table components covering DataTable, Columns, Column, Table, headers, rows, cells, footers, rendering rules, element/structure behavior, context interactions, and customization patterns.
  * Added a detailed overview and usage guide with data-provisioning patterns, examples for customization (headers, footers, expandable/multi-row items, custom structures), advanced patterns, type-safety guidance, and edge-case notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->